### PR TITLE
Update contentBase to static

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     ]
   },
   devServer: {
-    contentBase: path.join(__dirname, 'docs'), //`docs` as a GitHub Pages requirement
+    static: path.join(__dirname, 'docs'), //`docs` as a GitHub Pages requirement
     open: true,
   },
   resolve: {


### PR DESCRIPTION
Simple fix to update "contentBase" to "static" due to API behavior changes when updating latest 3P packages via 'npm audit fix --force'﻿
